### PR TITLE
Make sure that stw_sections can never overlap

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -171,7 +171,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
   caml_plat_lock(&all_domains_lock);
 
   /* wait until any in-progress STW sections end */
-  while (stw_leader) caml_plat_wait(&all_domains_cond);
+  while (atomic_load_acq(&stw_leader)) caml_plat_wait(&all_domains_cond);
 
   for (i = 0;
        i < Max_domains &&
@@ -522,16 +522,16 @@ static void decrement_stw_domains_still_processing()
   /* we check if we are the last to leave a stw section
      if so, clear the stw_leader to allow the new stw sections to start.
    */
+  caml_plat_lock(&all_domains_lock);
   intnat am_last = atomic_fetch_add(&stw_request.num_domains_still_processing, -1) == 1;
 
   if( am_last ) {
     /* release the STW lock to allow new STW sections */
-    caml_plat_lock(&all_domains_lock);
-    stw_leader = 0;
+    atomic_store_rel(&stw_leader, 0);
     caml_plat_broadcast(&all_domains_cond);
     caml_gc_log("clearing stw leader");
-    caml_plat_unlock(&all_domains_lock);
   }
+  caml_plat_unlock(&all_domains_lock);
 }
 
 static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
@@ -602,12 +602,12 @@ int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* da
      If it fails, handle interrupts (probably participating in
      an STW section) and return. */
   caml_plat_lock(&all_domains_lock);
-  if (stw_leader) {
+  if (atomic_load_acq(&stw_leader)) {
     caml_plat_unlock(&all_domains_lock);
     caml_handle_incoming_interrupts();
     return 0;
   } else {
-      stw_leader = domain_self;
+    atomic_store_rel(&stw_leader, domain_self);
   }
   caml_plat_unlock(&all_domains_lock);
 

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -517,6 +517,23 @@ int caml_global_barrier_num_domains()
   return stw_request.num_domains;
 }
 
+static void decrement_stw_domains_still_processing()
+{
+  /* we check if we are the last to leave a stw section
+     if so, clear the stw_leader to allow the new stw sections to start.
+   */
+  intnat am_last = atomic_fetch_add(&stw_request.num_domains_still_processing, -1) == 1;
+
+  if( am_last ) {
+    /* release the STW lock to allow new STW sections */
+    caml_plat_lock(&all_domains_lock);
+    stw_leader = 0;
+    caml_plat_broadcast(&all_domains_cond);
+    caml_gc_log("clearing stw leader");
+    caml_plat_unlock(&all_domains_lock);
+  }
+}
+
 static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
 {
   caml_domain_state* domain_state = Caml_state;
@@ -538,7 +555,8 @@ static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
   #ifdef DEBUG
   domain_state->inside_stw_handler = 0;
   #endif
-  atomic_fetch_add(&stw_request.num_domains_still_processing, -1);
+
+  decrement_stw_domains_still_processing();
 
   if( !stw_request.leave_when_done ) {
     SPIN_WAIT {
@@ -574,7 +592,7 @@ int caml_domain_is_in_stw() {
 int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* data, int leave_when_done)
 {
   caml_domain_state* domain_state = Caml_state;
-  
+
   int i;
   uintnat domains_participating = 1;
 
@@ -629,20 +647,15 @@ int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* da
   domain_state->inside_stw_handler = 0;
   #endif
 
-  /* release the STW lock before allowing other domains to continue */
-  caml_plat_lock(&all_domains_lock);
-  Assert (stw_leader == domain_self);
-  stw_leader = 0;
-  caml_plat_broadcast(&all_domains_cond);
-  caml_plat_unlock(&all_domains_lock);
-  atomic_fetch_add(&stw_request.num_domains_still_processing, -1);
-  
+  decrement_stw_domains_still_processing();
+
   if( !leave_when_done ) {
     SPIN_WAIT {
       if (atomic_load_acq(&stw_request.num_domains_still_processing) == 0)
         break;
     }
   }
+
   caml_ev_end("stw/leader");
   /* other domains might not have finished stw_handler yet, but they
      will finish as soon as they notice num_domains_still_processing
@@ -974,7 +987,7 @@ static void domain_terminate()
   caml_free_minor_tables(domain_state->minor_tables);
   domain_state->minor_tables = 0;
   caml_free_signal_stack();
-  
+
   if(domain_state->current_stack != NULL) {
     caml_free_stack(domain_state->current_stack);
   }

--- a/byterun/gc_ctrl.c
+++ b/byterun/gc_ctrl.c
@@ -187,9 +187,7 @@ CAMLprim value caml_gc_major(value v)
   Assert (v == Val_unit);
   caml_gc_log ("Major GC cycle requested");
   caml_ev_pause(EV_PAUSE_GC);
-  caml_try_stw_empty_minor_heap_on_all_domains();
-  /* TODO: is try really acceptable or do we need 'every time'
-  caml_empty_minor_heap (); */
+  caml_empty_minor_heaps_once();
   caml_finish_major_cycle();
   caml_final_do_calls ();
   caml_ev_resume();
@@ -204,9 +202,7 @@ CAMLprim value caml_gc_full_major(value v)
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
   for (i = 0; i < 3; i++) {
-    caml_try_stw_empty_minor_heap_on_all_domains();
-    /* TODO: is try really acceptable or do we need 'every time'
-    caml_empty_minor_heap (); */
+    caml_empty_minor_heaps_once();
     caml_finish_major_cycle();
     caml_final_do_calls ();
   }
@@ -219,9 +215,7 @@ CAMLprim value caml_gc_major_slice (value v)
   intnat res;
   CAMLassert (Is_long (v));
   caml_ev_pause(EV_PAUSE_GC);
-  caml_try_stw_empty_minor_heap_on_all_domains();
-  /* TODO: is try really acceptable or do we need 'every time'
-  caml_empty_minor_heap (); */
+  caml_empty_minor_heaps_once();
   res = caml_major_collection_slice(Long_val(v), 0);
   caml_ev_resume();
   caml_handle_gc_interrupt();

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -689,9 +689,7 @@ CAMLexport void caml_minor_collection (void)
   caml_ev_pause(EV_PAUSE_GC);
 
   caml_handle_incoming_interrupts ();
-  caml_try_stw_empty_minor_heap_on_all_domains();
-  /* TODO: is try really acceptable or do we need 'every time'
-  caml_empty_minor_heap (); */
+  caml_empty_minor_heaps_once();
   caml_handle_incoming_interrupts ();
   caml_major_collection_slice (0, 0);
   caml_final_do_calls();

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -272,10 +272,11 @@ static void oldify_one (void* st_v, value v, value *p)
   } while (tag == Infix_tag);
 
   if (tag == Cont_tag) {
-    struct stack_info* stk = Ptr_val(Op_val(v)[0]);
+    value stack_value = Op_val(v)[0];
     CAMLassert(Wosize_hd(hd) == 1 && infix_offset == 0);
     result = alloc_shared(1, Cont_tag);
     if( try_update_object_header(v, p, result, 0) ) {
+      struct stack_info* stk = Ptr_val(stack_value);
       Op_val(result)[0] = Val_ptr(stk);
       if (stk != NULL) {
         caml_scan_stack(&oldify_one, st, stk);

--- a/byterun/weak.c
+++ b/byterun/weak.c
@@ -163,7 +163,7 @@ void caml_ephe_clean (struct domain* d, value v) {
     if (release_data) {
       Op_val(v)[CAML_EPHE_DATA_OFFSET] = caml_ephe_none;
     } else {
-      CAMLassert (!Is_block(child) && !is_unmarked(child));
+      CAMLassert (!Is_block(child) || !is_unmarked(child));
     }
   }
 }


### PR DESCRIPTION
Make sure that stw_sections can never overlap (e.g. major GC while minor GC is happening), by having the last thread that leaves clear stw_leader