### PR TITLE
Promote all ephemerons unconditionally in minor_gc

### DIFF
--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -375,8 +375,7 @@ static void oldify_one (void* st_v, value v, value *p)
 /* Care needed with this test. It will only make sense if
    all minor heaps have been promoted
    as the liveness of the keys can only be known at that point */
-static inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re,
-                                         char* young_ptr, char* young_end)
+static inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re)
 {
   mlsize_t i;
   value child;

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -372,6 +372,9 @@ static void oldify_one (void* st_v, value v, value *p)
 }
 
 /* Test if the ephemeron is alive */
+/* Care needed with this test. It will only make sense if
+   all minor heaps have been promoted
+   as the liveness of the keys can only be known at that point */
 static inline int ephe_check_alive_data (struct caml_ephe_ref_elt *re,
                                          char* young_ptr, char* young_end)
 {
@@ -435,24 +438,24 @@ static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
     CAMLassert (Wosize_val(new_v));
   }
 
-  /* Oldify the data in the minor heap of alive ephemeron
-     During minor collection keys outside the minor heap are considered alive */
+  /* Oldify the key and data in the minor heap of all ephemerons touched in this
+     cycle
+    We are doing this to allow concurrent minor collections to resume
+    executing mutating code while others are still collecting.
+   */
   if( do_ephemerons ) {
     for (re = ephe_ref_table.base;
-        re < ephe_ref_table.ptr; re++) {
-      /* look only at ephemeron with data in the minor heap */
-      if (re->offset == CAML_EPHE_DATA_OFFSET) {
-        value *data = &Ephe_data(re->ephe);
-        if (*data != caml_ephe_none && Is_block(*data) && Is_minor(*data) ) {
-          resolve_infix_val(data);
-          if (get_header_val(*data) == 0) { /* Value copied to major heap */
-            *data = Op_val(*data)[0];
-          } else {
-            if (ephe_check_alive_data(re, young_ptr, young_end)) {
-              oldify_one(st, *data, data);
-              redo = 1; /* oldify_todo_list can still be 0 */
-            }
-          }
+         re < ephe_ref_table.ptr; re++) {
+      value *data = re->offset == CAML_EPHE_DATA_OFFSET
+              ? &Ephe_data(re->ephe)
+              :  &Op_val(re->ephe)[re->offset];
+      if (*data != caml_ephe_none && Is_block(*data) && Is_minor(*data) ) {
+        resolve_infix_val(data);
+        if (get_header_val(*data) == 0) { /* Value copied to major heap */
+          *data = Op_val(*data)[0];
+        } else {
+          oldify_one(st, *data, data);
+          redo = 1; /* oldify_todo_list can still be 0 */
         }
       }
     }
@@ -553,7 +556,7 @@ void caml_empty_minor_heap_promote (struct domain* domain, int not_alone)
   }
 
   caml_ev_begin("minor_gc/remembered_set/promote");
-  oldify_mopup (&st, 0);
+  oldify_mopup (&st, 1); /* ephemerons promoted here */
   caml_ev_end("minor_gc/remembered_set/promote");
   caml_ev_end("minor_gc/remembered_set");
 
@@ -573,32 +576,9 @@ void caml_empty_minor_heap_promote (struct domain* domain, int not_alone)
   caml_do_local_roots(&oldify_one, &st, domain, 0);
   caml_scan_stack(&oldify_one, &st, domain_state->current_stack);
   caml_ev_begin("minor_gc/local_roots/promote");
-  oldify_mopup (&st, 1);
+  oldify_mopup (&st, 0);
   caml_ev_end("minor_gc/local_roots/promote");
   caml_ev_end("minor_gc/local_roots");
-
-  caml_ev_begin("minor_gc/ephemerons");
-  for (re = minor_tables->ephe_ref.base;
-       re < minor_tables->ephe_ref.ptr; re++) {
-    CAMLassert (Ephe_domain(re->ephe) == domain);
-    if (re->offset == CAML_EPHE_DATA_OFFSET) {
-      /* Data field has already been handled in oldify_mopup. Handle only
-       * keys here. */
-      continue;
-    }
-    value* key = &Op_val(re->ephe)[re->offset];
-    if (*key != caml_ephe_none && Is_block(*key) && Is_minor(*key)) {
-      resolve_infix_val(key);
-      if (get_header_val(*key) == 0) { /* value copied to major heap */
-        *key = Op_val(*key)[0];
-      } else {
-        // CAMLassert(!ephe_check_alive_data(re,young_ptr,young_end));
-        *key = caml_ephe_none;
-        Ephe_data(re->ephe) = caml_ephe_none;
-      }
-    }
-  }
-  caml_ev_end("minor_gc/ephemerons");
 
   domain_state->stat_minor_words += Wsize_bsize (minor_allocated_bytes);
   domain_state->stat_minor_collections++;

--- a/testsuite/tests/weak-ephe-final/ephetest.ml
+++ b/testsuite/tests/weak-ephe-final/ephetest.ml
@@ -66,7 +66,7 @@ let test2 () =
   is_key_value test eph 125;
   is_data_value test eph 42;
   ra := ref 13;
-  Gc.minor ();
+  Gc.minor (); Gc.full_major ();
   is_key_unset test eph;
   is_data_unset test eph
 let () = (test2 [@inlined never]) ()
@@ -82,7 +82,7 @@ let test3 () =
   is_key_value test eph 125;
   is_data_value test eph 13;
   ra := ref 14;
-  Gc.minor ();
+  Gc.minor (); Gc.full_major ();
   is_key_unset test eph;
   is_data_unset test eph
 let () = (test3 [@inlined never]) ()
@@ -117,7 +117,7 @@ let test5 () =
   is_data_value test eph 43;
   !rb := ref 4;
   Gc.minor ();
-  Gc.minor ();
+  Gc.minor (); Gc.full_major ();
   is_key_unset test eph;
   is_data_unset test eph
 let () = (test5 [@inlined never]) ()

--- a/testsuite/tests/weak-ephe-final/weaklifetime.ml
+++ b/testsuite/tests/weak-ephe-final/weaklifetime.ml
@@ -31,7 +31,9 @@ let gccount () =
 (* Check the correctness condition on the data at (i,j):
    1. if the block is present, the weak pointer must be full
    2. if the block was removed at GC n, and the weak pointer is still
-      full, then the current GC must be at most n+1.
+      full, then the current GC must be at most n+2.
+      (could have promotion from minor during n+1 which keeps alive in n+1,
+      so will die at n+2)
 
    Then modify the data in one of the following ways:
    1. if the block and weak pointer are absent, fill them
@@ -41,7 +43,7 @@ let check_and_change i j =
   let gc1 = gccount () in
   match data.(i).objs.(j), Weak.check data.(i).wp j with
   | Present x, false -> assert false
-  | Absent n, true -> assert (gc1 <= n+1)
+  | Absent n, true -> assert (gc1 <= n+2)
   | Absent _, false ->
     let x = Array.make (1 + Random.int 10) 42 in
     data.(i).objs.(j) <- Present x;


### PR DESCRIPTION
This fixes a bug where the key could be in another minor heap but has not been marked yet. We also moved where we promote the ephemerons to before the remembered_set completes to allow early release to work reliably