### PR TITLE
Stw minor gc opportunistic major slice

### DIFF
--- a/byterun/caml/domain.h
+++ b/byterun/caml/domain.h
@@ -85,6 +85,10 @@ int caml_domain_is_in_stw();
 #endif
 
 void caml_run_on_all_running_domains_during_stw(void (*handler)(struct domain*, void*), void* data);
+int caml_try_run_on_all_domains_with_spin_work(void (*handler)(struct domain*, void*), void*,
+  void (*enter_spin_callback)(struct domain*, void*), void*,
+  void (*leave_spin_callback)(struct domain*, void*), void*,
+  int);
 int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void*, int);
 
 void caml_global_barrier();

--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -45,6 +45,8 @@ DOMAIN_STATE(uintnat, allocated_words)
 
 DOMAIN_STATE(uintnat, swept_words)
 
+DOMAIN_STATE(uintnat, opportunistic_work)
+
 DOMAIN_STATE(struct caml__roots_block*, local_roots)
 
 DOMAIN_STATE(struct caml_ephe_info*, ephe_info)

--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -25,6 +25,7 @@ typedef enum {
 } gc_phase_t;
 extern gc_phase_t caml_gc_phase;
 
+intnat caml_opportunistic_major_collection_slice (intnat, intnat* left /* out */);
 intnat caml_major_collection_slice (intnat, intnat* left /* out */);
 void caml_finish_sweeping(void);
 void caml_finish_marking (void);

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -465,6 +465,10 @@ static struct {
   int leave_when_done;
   int num_domains;
   atomic_uintnat barrier;
+  void (*enter_spin_callback)(struct domain*, void*);
+  void* enter_spin_data;
+  void (*leave_spin_callback)(struct domain*, void*);
+  void* leave_spin_data;
 } stw_request = {
   ATOMIC_UINTNAT_INIT(0),
   ATOMIC_UINTNAT_INIT(0),
@@ -472,7 +476,11 @@ static struct {
   NULL,
   0,
   0,
-  ATOMIC_UINTNAT_INIT(0)
+  ATOMIC_UINTNAT_INIT(0),
+  NULL,
+  NULL,
+  NULL,
+  NULL
 };
 
 /* sense-reversing barrier */
@@ -543,6 +551,9 @@ static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
     if (atomic_load_acq(&stw_request.domains_still_running) == 0)
       break;
     caml_handle_incoming_interrupts();
+
+    if (stw_request.enter_spin_callback)
+      stw_request.enter_spin_callback(domain, stw_request.enter_spin_data);
   }
   caml_ev_end("stw/api_barrier");
 
@@ -560,6 +571,9 @@ static void stw_handler(struct domain* domain, void* unused2, interrupt* done)
     SPIN_WAIT {
       if (atomic_load_acq(&stw_request.num_domains_still_processing) == 0)
         break;
+
+      if (stw_request.leave_spin_callback)
+        stw_request.leave_spin_callback(domain, stw_request.leave_spin_data);
     }
   }
 
@@ -588,7 +602,12 @@ int caml_domain_is_in_stw() {
 }
 #endif
 
-int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* data, int leave_when_done)
+int caml_try_run_on_all_domains_with_spin_work(
+  void (*handler)(struct domain*, void*), void* data,
+  void (*enter_spin_callback)(struct domain*, void*), void* enter_spin_data,
+  void (*leave_spin_callback)(struct domain*, void*), void* leave_spin_data,
+  int leave_when_done
+  )
 {
   caml_domain_state* domain_state = Caml_state;
 
@@ -635,6 +654,10 @@ int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* da
                    domains_participating);
   stw_request.callback = handler;
   stw_request.data = data;
+  stw_request.enter_spin_callback = enter_spin_callback;
+  stw_request.enter_spin_data = enter_spin_data;
+  stw_request.leave_spin_callback = leave_spin_callback;
+  stw_request.leave_spin_data = leave_spin_data;
 
   atomic_store_rel(&stw_request.domains_still_running, 0);
 
@@ -661,6 +684,11 @@ int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* da
      == 0, which will remain the case until they have responded to
      another interrupt from caml_run_on_all_domains */
   return 1;
+}
+
+int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void* data, int leave_when_done)
+{
+  caml_try_run_on_all_domains_with_spin_work(handler, data, 0, 0, 0, 0, leave_when_done);
 }
 
 void caml_interrupt_self() {
@@ -968,7 +996,7 @@ static void domain_terminate()
     if (handle_incoming(s) == 0 &&
         Caml_state->marking_done &&
         Caml_state->sweeping_done) {
-      
+
       finished = 1;
       s->terminating = 0;
       s->running = 0;
@@ -1077,7 +1105,7 @@ CAMLprim value caml_ml_domain_critical_section(value delta)
   return Val_unit;
 }
 
-#define Chunk_size 0x10000
+#define Chunk_size 0x400
 
 CAMLprim value caml_ml_domain_yield(value unused)
 {

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -1097,7 +1097,7 @@ CAMLprim value caml_ml_domain_yield(value unused)
       caml_plat_wait(&s->cond);
     } else {
       caml_plat_unlock(&s->lock);
-      caml_major_collection_slice(Chunk_size, &left);
+      caml_opportunistic_major_collection_slice(Chunk_size, &left);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);
@@ -1174,7 +1174,7 @@ CAMLprim value caml_ml_domain_yield_until(value t)
       }
     } else {
       caml_plat_unlock(&s->lock);
-      caml_major_collection_slice(Chunk_size, &left);
+      caml_opportunistic_major_collection_slice(Chunk_size, &left);
       if (left == Chunk_size)
         found_work = 0;
       caml_plat_lock(&s->lock);

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1101,7 +1101,7 @@ static intnat major_collection_slice(intnat howmuch,
      }
     } while (budget > 0 && available != left);
 
-    if (budget > 0) {
+    if (!opportunistic && budget > 0) {
       domain_state->sweeping_done = 1;
       atomic_fetch_add_verify_ge0(&num_domains_to_sweep, -1);
     }
@@ -1221,14 +1221,15 @@ mark_again:
   if (budget_left)
     *budget_left = budget;
 
-  caml_gc_log("Major slice: %lu alloc, %ld work, %ld sweep, %ld mark (%lu blocks)",
+  caml_gc_log("Major slice: %lu alloc, %ld work, %ld sweep, %ld mark (%lu blocks), %lu opp work",
               (unsigned long)domain_state->allocated_words,
               (long)computed_work, (long)sweep_work, (long)mark_work,
-              (unsigned long)(domain_state->stat_blocks_marked - blocks_marked_before));
+              (unsigned long)(domain_state->stat_blocks_marked - blocks_marked_before),
+              (unsigned long)domain_state->opportunistic_work);
   domain_state->stat_major_words += domain_state->allocated_words;
   domain_state->allocated_words = 0;
   if (opportunistic)
-  domain_state->opportunistic_work += computed_work - budget;
+    domain_state->opportunistic_work += computed_work - budget;
 
   if (!opportunistic && is_complete_phase_sweep_ephe(d)) {
     saved_major_cycle = caml_major_cycles_completed;

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -301,7 +301,7 @@ double caml_mean_space_overhead ()
 
 static uintnat default_slice_budget() {
   double p, heap_words;
-  intnat computed_work;
+  intnat computed_work, opportunistic_credit;
   /*
      Free memory at the start of the GC cycle (garbage + free list) (assumed):
                  FM = heap_words * caml_percent_free
@@ -349,6 +349,22 @@ static uintnat default_slice_budget() {
 
   computed_work = (intnat) (p * (heap_blocks + (heap_words * 100 / (100 + caml_percent_free))));
 
+  /* adjust computed work for opportunistic_work done by this domain already */
+  if ( Caml_state->opportunistic_work > computed_work ) {
+    /* bound the credit that opportunistic_work can have vs computed_work */
+    if (Caml_state->opportunistic_work > computed_work*2) {
+     Caml_state->opportunistic_work = 2*computed_work;
+    }
+
+    opportunistic_credit = computed_work;
+    Caml_state->opportunistic_work -= computed_work;
+    computed_work = 0;
+  } else {
+    opportunistic_credit = Caml_state->opportunistic_work;
+    Caml_state->opportunistic_work = 0;
+    computed_work -= opportunistic_credit;
+  }
+
   caml_gc_message (0x40, "heap_words = %"
                          ARCH_INTNAT_PRINTF_FORMAT "u\n",
                          (uintnat)heap_words);
@@ -359,6 +375,7 @@ static uintnat default_slice_budget() {
                          ARCH_INTNAT_PRINTF_FORMAT "uu\n",
                    (uintnat) (p * 1000000));
   caml_gc_message (0x40, "ordered work = %ld words\n", (intnat)-1);
+  caml_gc_message (0x40, "opportunistic work credit = %ld words\n", opportunistic_credit);
   caml_gc_message (0x40, "computed work = %ld words\n", computed_work);
 
   return computed_work;
@@ -956,6 +973,8 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused)
   /* Mark roots for new cycle */
   domain->state->marking_done = 0;
 
+  domain->state->opportunistic_work = 0;
+
   caml_ev_begin("major_gc/roots");
   caml_do_roots (&caml_darken, NULL, domain, 0);
   caml_ev_end("major_gc/roots");
@@ -1036,12 +1055,14 @@ static void try_complete_gc_phase (struct domain* domain, void* unused)
     }
   }
   caml_global_barrier_end(b);
+  domain->state->opportunistic_work = 0;
 }
 
 #define Chunk_size 0x4000
 
 static intnat major_collection_slice(intnat howmuch,
                                      intnat from_barrier,
+                                     intnat opportunistic,
                                      intnat* budget_left /* out */)
 {
   struct domain* d = caml_domain_self();
@@ -1138,59 +1159,61 @@ mark_again:
     caml_ev_end("major_gc/mark");
   mark_work -= budget;
 
-  /* Finalisers */
-  if (caml_gc_phase == Phase_mark_final &&
-      caml_final_update_first(d)) {
-    /* This domain has updated finalise first values */
-    atomic_fetch_add_verify_ge0(&num_domains_to_final_update_first, -1);
-    if (budget > 0 && !domain_state->marking_done)
-      goto mark_again;
-  }
-
-  if (caml_gc_phase == Phase_sweep_ephe &&
-      caml_final_update_last(d)) {
-    /* This domain has updated finalise last values */
-    atomic_fetch_add_verify_ge0(&num_domains_to_final_update_last, -1);
-    /* Nothing has been marked while updating last */
-  }
-
-  caml_adopt_orphaned_work();
-
-  /* Ephemerons */
-  saved_ephe_cycle = atomic_load_acq(&ephe_cycle_info.ephe_cycle);
-  if (domain_state->ephe_info->todo != (value) NULL &&
-      saved_ephe_cycle > domain_state->ephe_info->cycle) {
-    caml_ev_begin("major_gc/ephe_mark");
-    budget = ephe_mark(budget, saved_ephe_cycle);
-    caml_ev_end("major_gc/ephe_mark");
-    if (domain_state->ephe_info->todo == (value) NULL)
-      caml_ephe_todo_list_emptied ();
-    else if (budget > 0 && domain_state->marking_done)
-      record_ephe_marking_done(saved_ephe_cycle);
-    else if (budget > 0) goto mark_again;
-  }
-
-  if (caml_gc_phase == Phase_sweep_ephe &&
-      domain_state->ephe_info->todo != 0) {
-    caml_ev_begin("major_gc/ephe_sweep");
-    budget = ephe_sweep (d, budget);
-    caml_ev_end("major_gc/ephe_sweep");
-    if (domain_state->ephe_info->todo == 0) {
-      atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
+  if (!opportunistic) {
+    /* Finalisers */
+    if (caml_gc_phase == Phase_mark_final &&
+        caml_final_update_first(d)) {
+      /* This domain has updated finalise first values */
+      atomic_fetch_add_verify_ge0(&num_domains_to_final_update_first, -1);
+      if (budget > 0 && !domain_state->marking_done)
+        goto mark_again;
     }
-  }
 
-  /* Complete GC phase */
-  if (is_complete_phase_sweep_and_mark_main(d) ||
-      is_complete_phase_mark_final (d)) {
-    caml_ev_begin("major_gc/phase_change");
-    if (from_barrier) {
-      try_complete_gc_phase (d, (void*)0);
-    } else {
-      caml_try_run_on_all_domains (&try_complete_gc_phase, 0, 0);
+    if (caml_gc_phase == Phase_sweep_ephe &&
+        caml_final_update_last(d)) {
+      /* This domain has updated finalise last values */
+      atomic_fetch_add_verify_ge0(&num_domains_to_final_update_last, -1);
+      /* Nothing has been marked while updating last */
     }
-    caml_ev_end("major_gc/phase_change");
-    if (budget > 0) goto mark_again;
+
+    caml_adopt_orphaned_work();
+
+    /* Ephemerons */
+    saved_ephe_cycle = atomic_load_acq(&ephe_cycle_info.ephe_cycle);
+    if (domain_state->ephe_info->todo != (value) NULL &&
+        saved_ephe_cycle > domain_state->ephe_info->cycle) {
+      caml_ev_begin("major_gc/ephe_mark");
+      budget = ephe_mark(budget, saved_ephe_cycle);
+      caml_ev_end("major_gc/ephe_mark");
+      if (domain_state->ephe_info->todo == (value) NULL)
+        caml_ephe_todo_list_emptied ();
+      else if (budget > 0 && domain_state->marking_done)
+        record_ephe_marking_done(saved_ephe_cycle);
+      else if (budget > 0) goto mark_again;
+    }
+
+    if (caml_gc_phase == Phase_sweep_ephe &&
+        domain_state->ephe_info->todo != 0) {
+      caml_ev_begin("major_gc/ephe_sweep");
+      budget = ephe_sweep (d, budget);
+      caml_ev_end("major_gc/ephe_sweep");
+      if (domain_state->ephe_info->todo == 0) {
+        atomic_fetch_add_verify_ge0(&num_domains_to_ephe_sweep, -1);
+      }
+    }
+
+    /* Complete GC phase */
+    if (is_complete_phase_sweep_and_mark_main(d) ||
+        is_complete_phase_mark_final (d)) {
+      caml_ev_begin("major_gc/phase_change");
+      if (from_barrier) {
+        try_complete_gc_phase (d, (void*)0);
+      } else {
+        caml_try_run_on_all_domains (&try_complete_gc_phase, 0, 0);
+      }
+      caml_ev_end("major_gc/phase_change");
+      if (budget > 0) goto mark_again;
+    }
   }
 
   caml_ev_end("major_gc/slice");
@@ -1204,8 +1227,10 @@ mark_again:
               (unsigned long)(domain_state->stat_blocks_marked - blocks_marked_before));
   domain_state->stat_major_words += domain_state->allocated_words;
   domain_state->allocated_words = 0;
+  if (opportunistic)
+  domain_state->opportunistic_work += computed_work - budget;
 
-  if (is_complete_phase_sweep_ephe(d)) {
+  if (!opportunistic && is_complete_phase_sweep_ephe(d)) {
     saved_major_cycle = caml_major_cycles_completed;
     /* To handle the case where multiple domains try to finish the major
       cycle simultaneously, we loop until the current cycle has ended,
@@ -1225,9 +1250,14 @@ mark_again:
 }
 
 
+intnat caml_opportunistic_major_collection_slice(intnat howmuch, intnat* budget_left /* out */)
+{
+  return major_collection_slice(howmuch, 0, 1, budget_left);
+}
+
 intnat caml_major_collection_slice(intnat howmuch, intnat* budget_left /* out */)
 {
-  return major_collection_slice(howmuch, 0, budget_left);
+  return major_collection_slice(howmuch, 0, 0, budget_left);
 }
 
 static void finish_major_cycle_callback (struct domain* domain, void* arg)
@@ -1237,7 +1267,7 @@ static void finish_major_cycle_callback (struct domain* domain, void* arg)
 
   caml_stw_empty_minor_heap(domain, (void*)0);
   while (saved_major_cycles == caml_major_cycles_completed) {
-    major_collection_slice(10000000, 1, 0);
+    major_collection_slice(10000000, 1, 0, 0);
   }
 }
 
@@ -1449,6 +1479,7 @@ int caml_init_major_gc(caml_domain_state* d) {
   d->sweeping_done = 1;
   d->marking_done = 1;
   d->stealing = 0;
+  d->opportunistic_work = 0;
   /* Finalisers. Fresh domains participate in updating finalisers. */
   d->final_info = caml_alloc_final_info ();
   if(d->final_info == NULL) {

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -518,7 +518,15 @@ static void mark_stack_push(struct mark_stack* stk, mark_entry e)
       /* nothing left to mark */
       return;
     v = Op_val(e.block)[e.offset];
-#if DEBUG
+#if 0
+/* #if DEBUG
+   ctk21: don't think this debug block is correct or safe
+   The block will be in a remembered set but not necessarily the one who owns it
+   because minor heaps are shared.
+   Also we can't scan all the minor_tables with minor early release as the
+   data structures can move underneath us
+    */
+
     /* Here we check that if v is a reference to a block on the minor heap then it is definitely
        contained within the remembered set */
     if( Is_block(v) && Is_minor(v) ) {

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -626,11 +626,11 @@ void caml_empty_minor_heap_promote (struct domain* domain, int domains_in_minor_
   oldify_mopup (&st, 1); /* ephemerons promoted here */
   caml_ev_end("minor_gc/remembered_set/promote");
   caml_ev_end("minor_gc/remembered_set");
-  caml_gc_log("promoted %d roots, %d bytes", remembered_roots, st.live_bytes);
+  caml_gc_log("promoted %d roots, %lu bytes", remembered_roots, st.live_bytes);
 
 #ifdef DEBUG
   caml_global_barrier();
-  caml_gc_log("ref_base: %ul, ref_ptr: %ul", self_minor_tables->major_ref.base, self_minor_tables->major_ref.ptr);
+  caml_gc_log("ref_base: %lu, ref_ptr: %lu", self_minor_tables->major_ref.base, self_minor_tables->major_ref.ptr);
   for (r = self_minor_tables->major_ref.base;
        r < self_minor_tables->major_ref.ptr; r++) {
     value vnew = **r;


### PR DESCRIPTION
This PR adds opportunistic major slice marking to the stw_minor entry barrier. 
This means that threads waiting for the STW minor gc to start can do some marking work while they wait for all threads to join the STW minor gc section. 