### PR TITLE
Stw minor gc shortcut opportunistic

### DIFF
--- a/byterun/caml/major_gc.h
+++ b/byterun/caml/major_gc.h
@@ -25,6 +25,7 @@ typedef enum {
 } gc_phase_t;
 extern gc_phase_t caml_gc_phase;
 
+intnat caml_is_opportunistic_work_available ();
 intnat caml_opportunistic_major_collection_slice (intnat, intnat* left /* out */);
 intnat caml_major_collection_slice (intnat, intnat* left /* out */);
 void caml_finish_sweeping(void);

--- a/byterun/eventlog.c
+++ b/byterun/eventlog.c
@@ -40,7 +40,7 @@ static struct evbuf_list_node evbuf_head =
 static FILE* output;
 static int64_t startup_timestamp;
 
-#define EVENT_BUF_SIZE 4096
+#define EVENT_BUF_SIZE 32768
 struct event_buffer {
   struct evbuf_list_node list;
   uintnat ev_flushed;

--- a/byterun/eventlog.c
+++ b/byterun/eventlog.c
@@ -77,6 +77,7 @@ static void flush_events(FILE* out, struct event_buffer* eb);
 static void thread_teardown_evbuf(void* p)
 {
   CAMLassert(p == evbuf);
+  if(!evbuf) return;
   caml_plat_lock(&lock);
   flush_events(output, evbuf);
   /* remove from global list */

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -748,9 +748,13 @@ void caml_stw_empty_minor_heap (struct domain* domain, void* unused)
 
 void caml_do_opportunistic_major_slice(struct domain* domain, void* unused)
 {
-  caml_ev_begin("minor_gc/opportunistic_major_slice");
-  caml_opportunistic_major_collection_slice(0x200, 0);
-  caml_ev_end("minor_gc/opportunistic_major_slice");
+  /* NB: need to put guard around the ev logs to prevent
+    spam when we poll */
+  if (caml_opportunistic_major_work_available()) {
+    caml_ev_begin("minor_gc/opportunistic_major_slice");
+    caml_opportunistic_major_collection_slice(0x200, 0);
+    caml_ev_end("minor_gc/opportunistic_major_slice");
+  }
 }
 
 /* must be called outside a STW section */


### PR DESCRIPTION
This PR avoids calling `caml_ev_begin`/`caml_ev_end` in opportunistic minor gc slices by checking first if there will be any work to do. This significantly cuts the number of entries in an event log file.