### PR TITLE
Always update budget_left in major_collection_slice

### DIFF
--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1094,8 +1094,10 @@ static intnat major_collection_slice(intnat howmuch,
 
   /* shortcut out if there is no opportunistic work to be done
    * NB: needed particularly to avoid caml_ev spam when polling */
-  if (opportunistic && !caml_opportunistic_major_work_available())
+  if (opportunistic && !caml_opportunistic_major_work_available()) {
+    if (budget_left) *budget_left = budget;
     return computed_work;
+  }
 
   caml_ev_begin("major_gc/slice");
 
@@ -1123,6 +1125,7 @@ static intnat major_collection_slice(intnat howmuch,
       if( saved_major_cycle != caml_major_cycles_completed ) {
         caml_ev_end("major_gc/sweep");
         caml_ev_end("major_gc/slice");
+        if (budget_left) *budget_left = budget;
         return computed_work;
       }
     /* need to check if sweeping_done by the incoming interrupt */
@@ -1152,6 +1155,7 @@ mark_again:
       if( saved_major_cycle != caml_major_cycles_completed ) {
         caml_ev_end("major_gc/mark");
         caml_ev_end("major_gc/slice");
+        if (budget_left) *budget_left = budget;
         return computed_work;
       }
     } else if (0) {


### PR DESCRIPTION
Sometimes `major_collection_slice` didn't update `*budget_left`, which confused `caml_ml_domain_yield` because it did this:
```
      caml_opportunistic_major_collection_slice(Chunk_size, &left);
      if (left == Chunk_size)
        found_work = 0;
```
The lack of update meant it assumed the major slice always found work, leading to busy looping on a contended lock.

(Fixing this cuts ~1/3 off the runtime of game_of_life_multicore)