### PR TITLE
Use more lightweight synchronisation to acknowledge interrupts

### DIFF
--- a/byterun/caml/domain.h
+++ b/byterun/caml/domain.h
@@ -85,11 +85,11 @@ int caml_domain_is_in_stw();
 #endif
 
 void caml_run_on_all_running_domains_during_stw(void (*handler)(struct domain*, void*), void* data);
-int caml_try_run_on_all_domains_with_spin_work(void (*handler)(struct domain*, void*), void*,
+int caml_try_run_on_all_domains_with_spin_work(void (*handler)(struct domain*, void*, int*), void*,
   void (*enter_spin_callback)(struct domain*, void*), void*,
   void (*leave_spin_callback)(struct domain*, void*), void*,
   int);
-int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*), void*, int);
+int caml_try_run_on_all_domains(void (*handler)(struct domain*, void*,int*), void*, int);
 
 void caml_global_barrier();
 

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -57,7 +57,7 @@ struct caml_minor_tables {
 struct domain;
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_stw_empty_minor_heap (struct domain* domain, void* unused); /* in STW */
+extern void caml_stw_empty_minor_heap (struct domain* domain, void* unused, int* participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void caml_minor_collection (void);

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -1094,8 +1094,10 @@ static intnat major_collection_slice(intnat howmuch,
 
   /* shortcut out if there is no opportunistic work to be done
    * NB: needed particularly to avoid caml_ev spam when polling */
-  if (opportunistic && !caml_opportunistic_major_work_available())
+  if (opportunistic && !caml_opportunistic_major_work_available()) {
+    if (budget_left) *budget_left = budget;
     return computed_work;
+  }
 
   caml_ev_begin("major_gc/slice");
 
@@ -1123,6 +1125,7 @@ static intnat major_collection_slice(intnat howmuch,
       if( saved_major_cycle != caml_major_cycles_completed ) {
         caml_ev_end("major_gc/sweep");
         caml_ev_end("major_gc/slice");
+        if (budget_left) *budget_left = budget;
         return computed_work;
       }
     /* need to check if sweeping_done by the incoming interrupt */
@@ -1152,6 +1155,7 @@ mark_again:
       if( saved_major_cycle != caml_major_cycles_completed ) {
         caml_ev_end("major_gc/mark");
         caml_ev_end("major_gc/slice");
+        if (budget_left) *budget_left = budget;
         return computed_work;
       }
     } else if (0) {


### PR DESCRIPTION
During STW pauses, there was contention on the STW leader's interruptor lock as all of the other domains tried to acknowledge their interrupts simultaneously.

This heavyweight sync was only present as a fallback case for domains that blocked before acknowledging an interrupt (an obscure case of the read barrier mechanism - what if a domain finds that it no longer owns an object by the time an interrupt arrives?). It's not relevant in the STW-minor case, and just slows things down.

This is based off #22. There are two other commits: the first squashes some warnings, the second makes the change.