### PR TITLE
Smg write barrier optim

### DIFF
--- a/byterun/caml/memory.h
+++ b/byterun/caml/memory.h
@@ -52,11 +52,11 @@ CAMLextern value caml_alloc_shr_no_raise (mlsize_t wosize, tag_t);
 CAMLextern void caml_adjust_gc_speed (mlsize_t, mlsize_t);
 CAMLextern void caml_alloc_dependent_memory (mlsize_t);
 CAMLextern void caml_free_dependent_memory (mlsize_t);
-CAMLextern void caml_modify_field (value, int, value);
+CAMLextern void caml_modify_field (value, intnat, value);
 #define caml_modify_field caml_modify_field
-CAMLextern int caml_atomic_cas_field (value, int, value, value);
-CAMLextern value caml_read_barrier (value, int);
-CAMLextern void caml_initialize_field (value, int, value);
+CAMLextern int caml_atomic_cas_field (value, intnat, value, value);
+CAMLextern value caml_read_barrier (value, intnat);
+CAMLextern void caml_initialize_field (value, intnat, value);
 #define caml_initialize_field caml_initialize_field
 CAMLextern void caml_blit_fields (value src, int srcoff, value dst, int dstoff, int n);
 CAMLextern value caml_check_urgent_gc (value);

--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -49,9 +49,6 @@ struct caml_minor_tables {
   struct caml_ref_table major_ref;
   struct caml_ephe_ref_table ephe_ref;
   struct caml_custom_table custom;
-#ifdef DEBUG
-  struct caml_ref_table minor_ref;
-#endif
 };
 
 struct domain;

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -218,6 +218,9 @@ bits  63        (64-P) (63-P)        10 9     8 7   0
 #define Is_minor(val) \
   ((((uintnat)(val) ^ (uintnat)Caml_state) & Minor_val_bitmask) == 0)
 
+#define Is_block_and_young(val) Is_young(val)
+#define Is_block_and_minor(val) Is_minor(val)
+
 /* NOTE: [Forward_tag] and [Infix_tag] must be just under
    [No_scan_tag], with [Infix_tag] the lower one.
    See [caml_oldify_one] in minor_gc.c for more details.

--- a/byterun/caml/mlvalues.h
+++ b/byterun/caml/mlvalues.h
@@ -430,9 +430,9 @@ static inline value Field_imm(value x, int i) {
   return v;
 }
 
-CAMLextern value caml_read_barrier(value, int);
+CAMLextern value caml_read_barrier(value, intnat);
 
-static inline void caml_read_field(value x, int i, value* ret) {
+static inline void caml_read_field(value x, intnat i, value* ret) {
   Assert (Hd_val(x));
   /* See Note [MM] in memory.c */
   value v = atomic_load_explicit(&Op_atomic_val(x)[i], memory_order_relaxed);

--- a/byterun/memory.c
+++ b/byterun/memory.c
@@ -124,11 +124,11 @@
    generated.
 */
 
-static void write_barrier(value obj, int field, value old_val, value new_val) __attribute__((always_inline));
+static void write_barrier(value obj, intnat field, value old_val, value new_val) __attribute__((always_inline));
 
 /* The write barrier does not read or write the heap, it just
    modifies domain-local data structures. */
-static void write_barrier(value obj, int field, value old_val, value new_val)
+static void write_barrier(value obj, intnat field, value old_val, value new_val)
 {
   /* HACK: can't assert when get old C-api style pointers
     Assert (Is_block(obj)); */
@@ -148,7 +148,7 @@ static void write_barrier(value obj, int field, value old_val, value new_val)
    }
 }
 
-CAMLexport void caml_modify_field (value obj, int field, value val)
+CAMLexport void caml_modify_field (value obj, intnat field, value val)
 {
   Assert (Is_block(obj));
   Assert(field >= 0 && field < Wosize_val(obj));
@@ -179,7 +179,7 @@ CAMLexport CAMLweakdef void caml_modify (value *fp, value val)
                         memory_order_release);
 }
 
-CAMLexport void caml_initialize_field (value obj, int field, value val)
+CAMLexport void caml_initialize_field (value obj, intnat field, value val)
 {
   Assert(Is_block(obj));
   Assert(0 <= field && field < Wosize_val(obj));
@@ -215,7 +215,7 @@ CAMLexport CAMLweakdef void caml_initialize (value *fp, value val)
   *fp = val;
 }
 
-CAMLexport int caml_atomic_cas_field (value obj, int field, value oldval, value newval)
+CAMLexport int caml_atomic_cas_field (value obj, intnat field, value oldval, value newval)
 {
   if (caml_domain_alone()) {
     /* non-atomic CAS since only this thread can access the object */
@@ -447,7 +447,7 @@ static void send_read_fault(struct read_fault_req* req)
   }
 }
 
-CAMLexport value caml_read_barrier(value obj, int field)
+CAMLexport value caml_read_barrier(value obj, intnat field)
 {
   /* ctk21: no-op the read barrier as part of experiment */
   CAMLparam1(obj);

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -100,9 +100,6 @@ void reset_minor_tables(struct caml_minor_tables* r)
   reset_table((struct generic_table *)&r->major_ref);
   reset_table((struct generic_table *)&r->ephe_ref);
   reset_table((struct generic_table *)&r->custom);
-#ifdef DEBUG
-  reset_table((struct generic_table *)&r->minor_ref);
-#endif
 }
 
 void caml_free_minor_tables(struct caml_minor_tables* r)
@@ -520,9 +517,6 @@ void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
   clear_table ((struct generic_table *)&minor_tables->major_ref);
   clear_table ((struct generic_table *)&minor_tables->ephe_ref);
   clear_table ((struct generic_table *)&minor_tables->custom);
-#ifdef DEBUG
-  clear_table ((struct generic_table *)&minor_tables->minor_ref);
-#endif
 
   asize_t wsize = domain_state->minor_heap_wsz;
 


### PR DESCRIPTION
This PR goes a little way to closing the regression seen on `chameneos_redux_lwt` in sandmark vs 4.06.1. I was seeing:
 - 4.06.1: ~1.50s
 - stw_minor_gc (baseline): ~1.75s
 - stw_minor_gc (with this change): ~1.65s 

There are two strands: 
 - use intnat to avoid sign extension instructions in the generated code
 - cleanup `write_barrier` and use logic that more closely matches `caml_modify` in 4.06.1