### PR TITLE
Cleanup external calls to caml_stw_empty_minor_heap

### DIFF
--- a/byterun/caml/minor_gc.h
+++ b/byterun/caml/minor_gc.h
@@ -54,7 +54,7 @@ struct caml_minor_tables {
 struct domain;
 
 extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
-extern void caml_stw_empty_minor_heap (struct domain* domain, void* unused, int participating_count, struct domain** participating); /* in STW */
+extern void caml_empty_minor_heap_from_stw (struct domain* domain, void* unused, int participating_count, struct domain** participating); /* in STW */
 extern int caml_try_stw_empty_minor_heap_on_all_domains(); /* out STW */
 extern void caml_empty_minor_heaps_once(); /* out STW */
 CAMLextern void caml_minor_collection (void);

--- a/byterun/major_gc.c
+++ b/byterun/major_gc.c
@@ -872,13 +872,7 @@ static void cycle_all_domains_callback(struct domain* domain, void* unused,
   CAMLassert(atomic_load(&num_domains_to_sweep) == 0);
   CAMLassert(atomic_load(&num_domains_to_ephe_sweep) == 0);
 
-  barrier_status b = caml_global_barrier_begin();
-  if( caml_global_barrier_is_final(b) ) {
-    caml_empty_minor_heap_setup(domain);
-  }
-  caml_global_barrier_end(b);
-
-  caml_stw_empty_minor_heap(domain, (void*)0, participating_count, participating);
+  caml_empty_minor_heap_from_stw(domain, (void*)0, participating_count, participating);
 
   caml_ev_begin("major_gc/stw");
 
@@ -1292,14 +1286,9 @@ static void finish_major_cycle_callback (struct domain* domain, void* arg,
 {
   uintnat saved_major_cycles = (uintnat)arg;
   CAMLassert (domain == caml_domain_self());
-  
-  barrier_status b = caml_global_barrier_begin();
-  if( caml_global_barrier_is_final(b) ) {
-    caml_empty_minor_heap_setup(domain);
-  }
-  caml_global_barrier_end(b);
 
-  caml_stw_empty_minor_heap(domain, (void*)0, participating_count, participating);
+  caml_empty_minor_heap_from_stw(domain, (void*)0, participating_count, participating);
+
   while (saved_major_cycles == caml_major_cycles_completed) {
     major_collection_slice(10000000, participating_count, participating, 0, 0);
   }


### PR DESCRIPTION
Make all calls from outside minor_gc.c use helper to do barrier setup for `caml_stw_empty_minor_heap`