### PR TITLE
Stats print heap_words and top_heap_words

### DIFF
--- a/byterun/caml/shared_heap.h
+++ b/byterun/caml/shared_heap.h
@@ -19,6 +19,7 @@ value* caml_shared_try_alloc(struct caml_heap_state*, mlsize_t wosize, tag_t tag
 void caml_sample_heap_stats(struct caml_heap_state*, struct heap_stats*);
 
 uintnat caml_heap_size(struct caml_heap_state*);
+uintnat caml_top_heap_words(struct caml_heap_state*);
 uintnat caml_heap_blocks(struct caml_heap_state*);
 
 struct pool* caml_pool_of_shared_block(value v);

--- a/byterun/shared_heap.c
+++ b/byterun/shared_heap.c
@@ -54,7 +54,6 @@ struct {
   NULL
 };
 
-
 /* readable and writable only by the current thread */
 struct caml_heap_state {
   pool* avail_pools[NUM_SIZECLASSES];
@@ -512,6 +511,11 @@ intnat caml_sweep(struct caml_heap_state* local, intnat work) {
 uintnat caml_heap_size(struct caml_heap_state* local) {
   return Bsize_wsize(local->stats.pool_words + local->stats.large_words);
 }
+
+uintnat caml_top_heap_words(struct caml_heap_state* local) {
+  return local->stats.pool_max_words + local->stats.large_max_words;
+}
+
 
 uintnat caml_heap_blocks(struct caml_heap_state* local) {
   return local->stats.pool_live_blocks + local->stats.large_blocks;


### PR DESCRIPTION
Stats print heap_words and top_heap_words of the the current domain if no major GC were done

Mirror of: https://github.com/ocaml-multicore/ocaml-multicore/pull/297