### PR TITLE
Optimised caml_modify_field

### DIFF
--- a/asmcomp/cmmgen.ml
+++ b/asmcomp/cmmgen.ml
@@ -702,7 +702,7 @@ let float_array_ref dbg arr ofs =
   box_float dbg (unboxed_float_array_ref arr ofs dbg)
 
 let addr_array_set arr ofs newval dbg =
-  Cop(Cextcall("caml_modify_field", typ_void, false, None),
+  Cop(Cextcall("caml_modify_field_asm", typ_void, false, None),
       [arr; untag_int ofs dbg; newval], dbg)
 let addr_array_initialize arr ofs newval dbg =
   Cop(Cextcall("caml_initialize_field", typ_void, false, None),
@@ -2113,7 +2113,7 @@ and transl_prim_2 env p arg1 arg2 dbg =
   | Psetfield(n, ptr, init) ->
       begin match assignment_kind ptr init with
       | Caml_modify ->
-        return_unit(Cop(Cextcall("caml_modify_field", typ_void, false, None),
+        return_unit(Cop(Cextcall("caml_modify_field_asm", typ_void, false, None),
                         [transl env arg1; Cconst_int n; transl env arg2],
                         dbg))
       | Caml_initialize ->

--- a/asmrun/amd64.S
+++ b/asmrun/amd64.S
@@ -94,6 +94,8 @@
 
 #define CAML_CONFIG_H_NO_TYPEDEFS
 #include "../byterun/caml/config.h"
+        .equ Minor_val_bitmask,\
+          (1 | ~((1 << (Minor_heap_align_bits + Minor_heap_sel_bits)) - 1))
 
         .set    domain_curr_field, 0
 #define DOMAIN_STATE(c_type, name) \
@@ -478,6 +480,20 @@ CFI_STARTPROC
         pushq   %rax
         RESTORE_ALL_REGS
         popq    %rax
+        ret
+CFI_ENDPROC
+
+/* runs on C stack with C calling convention.
+   optimisation: use ocaml calling convention and SAVE_ALL_REGS?
+   args: C_ARG_1: object, C_ARG_2: field idx, C_ARG_3: new value */
+FUNCTION(G(caml_modify_field_asm))
+CFI_STARTPROC
+        movq    C_ARG_1, %r11
+        xorq    %r14, %r11
+        testq   $Minor_val_bitmask, %r11
+        jz      1f
+        jmp     GCALL(caml_modify_field)
+1:      movq    C_ARG_3, 0(C_ARG_1,C_ARG_2,8)
         ret
 CFI_ENDPROC
 


### PR DESCRIPTION
This patch makes calls to caml_modify_field in native code go through a fastpath in amd64.S, which should remove some overhead when objects in the minor heap are being mutated.