### PR TITLE
Revert double buffering of minor heap

### DIFF
--- a/byterun/caml/domain_state.tbl
+++ b/byterun/caml/domain_state.tbl
@@ -12,9 +12,6 @@ DOMAIN_STATE(char*, young_start)
 DOMAIN_STATE(char*, young_end)
 /* End of the minor heap. always(young_end <= young_ptr <= young_start) */
 
-DOMAIN_STATE(int, young_phase)
-/* The current minor heap being used. This is for double buffering */
-
 DOMAIN_STATE(struct stack_info*, current_stack)
 /* Current stack */
 

--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -140,7 +140,6 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 
 int caml_reallocate_minor_heap(asize_t wsize)
 {
-  asize_t double_wsize;
   caml_domain_state* domain_state = Caml_state;
   Assert(domain_state->young_ptr == domain_state->young_end);
 
@@ -151,23 +150,21 @@ int caml_reallocate_minor_heap(asize_t wsize)
                     domain_self->minor_heap_area_end - domain_self->minor_heap_area);
 
   /* we allocate a double buffer to allow early release in minor_gc */
-  double_wsize = caml_norm_minor_heap_size(wsize * 2);
-  wsize = double_wsize/2;
+  wsize = caml_norm_minor_heap_size(wsize);
 
-  if (!caml_mem_commit((void*)domain_self->minor_heap_area, Bsize_wsize(double_wsize))) {
+  if (!caml_mem_commit((void*)domain_self->minor_heap_area, Bsize_wsize(wsize))) {
     return -1;
   }
 
 #ifdef DEBUG
   {
     uintnat* p = (uintnat*)domain_self->minor_heap_area;
-    for (; p < (uintnat*)(domain_self->minor_heap_area + Bsize_wsize(double_wsize)); p++)
+    for (; p < (uintnat*)(domain_self->minor_heap_area + Bsize_wsize(wsize)); p++)
       *p = Debug_uninit_align;
   }
 #endif
 
   domain_state->minor_heap_wsz = wsize;
-  domain_state->young_phase = 0;
 
   domain_state->young_start = (char*)domain_self->minor_heap_area;
   domain_state->young_end = (char*)(domain_self->minor_heap_area + Bsize_wsize(wsize));

--- a/byterun/minor_gc.c
+++ b/byterun/minor_gc.c
@@ -517,18 +517,6 @@ void caml_empty_minor_heap_domain_clear (struct domain* domain, void* unused)
 
   asize_t wsize = domain_state->minor_heap_wsz;
 
-  if( domain_state->young_phase == 0 ) {
-    domain_state->young_start = (char*)domain_state->young_end;
-    domain_state->young_end = (char*)(domain_state->young_start + Bsize_wsize(wsize) );
-
-    domain_state->young_phase = 1;
-  } else {
-    domain_state->young_end = (char*)(domain_state->young_end - Bsize_wsize(wsize) );
-    domain_state->young_start = (char*)(domain_state->young_end - Bsize_wsize(wsize) );
-
-    domain_state->young_phase = 0;
-  }
-
   domain_state->young_limit = domain_state->young_start;
   domain_state->young_ptr = domain_state->young_end;
 }


### PR DESCRIPTION
No longer need the double buffering and is affecting the RSS numbers, so reverting it. 