### PR TITLE
check for stw_leader before we take the locks

### DIFF
--- a/byterun/domain.c
+++ b/byterun/domain.c
@@ -642,6 +642,12 @@ int caml_try_run_on_all_domains_with_spin_work(
   int i;
   uintnat domains_participating = 0;
 
+  // Don't take the lock if there's already a stw leader
+  if( atomic_load_acq(&stw_leader) ) {
+    caml_handle_incoming_interrupts(); 
+    return 0;
+  }
+
   caml_gc_log("requesting STW");
 
   /* Try to take the lock by setting ourselves as the stw_leader.


### PR DESCRIPTION
At certain points all domains will try to call for a particular stop-the-world action, this currently results in them all contending over the `all_domains_lock`. 

This change avoids this happening though at the cost of potentially spurious failures due to races. As calls to `caml_try_run_on_all_domains_with_spin_work` can fail anyway though, callers who need to confirm an action has taken place do so themselves already.